### PR TITLE
Compatibility symfony 2.7

### DIFF
--- a/Routing/Router.php
+++ b/Routing/Router.php
@@ -224,7 +224,7 @@ class Router extends BaseRouter
             $cache->write($dumper->dump($options), $routeCollection->getResources());
         }
 
-        require_once $cache;
+        require_once $cache->getPath();
 
         return $this->matcher = new $class($this->context);
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "target-dir": "Blablacar/I18nRoutingBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
fix deprecated in sf27 on ConfgCache::__toString() method
